### PR TITLE
read booleans from config and fix spanning monitors

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 180
+per-file-ignores = banner.py:F401

--- a/.github/workflows/python-linting.yaml
+++ b/.github/workflows/python-linting.yaml
@@ -1,0 +1,48 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python linting
+
+on:
+  push:
+    paths:
+      - '**.py'
+  pull_request:
+    paths:
+      - '**.py'
+
+jobs:
+  flake8:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 2
+      uses: actions/setup-python@v2
+      with:
+        python-version: '2.7'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        flake8 classification_banner
+
+  pylint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 2
+      uses: actions/setup-python@v2
+      with:
+        python-version: '2.7'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with pylint
+      run: |
+        pylint classification_banner

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,587 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=127
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, `new` is for `{}` formatting,and `fstr` is for f-strings.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: en_GB (myspell), en_AG
+# (myspell), en_AU (myspell), en_BS (myspell), en_BW (myspell), en_BZ
+# (myspell), en_CA (myspell), en_DK (myspell), en_GH (myspell), en_HK
+# (myspell), en_IE (myspell), en_IN (myspell), en_JM (myspell), en_MW
+# (myspell), en_NA (myspell), en_NG (myspell), en_NZ (myspell), en_PH
+# (myspell), en_SG (myspell), en_TT (myspell), en_ZA (myspell), en_ZM
+# (myspell), en_ZW (myspell), en_US (myspell).
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception
+

--- a/Contributors.md
+++ b/Contributors.md
@@ -7,3 +7,4 @@ The following people have contributed to the classification-banner project
 * Frank Caviggia <fcaviggia@gmail.com>
 * Brian Clemens <brianfclemens@gmail.com>
 * Gunnar Hellekson <gunnar@hellekson.com>
+* Kenyon Ralph <kenyon@kenyonralph.com>

--- a/Contributors.md
+++ b/Contributors.md
@@ -8,3 +8,4 @@ The following people have contributed to the classification-banner project
 * Brian Clemens <brianfclemens@gmail.com>
 * Gunnar Hellekson <gunnar@hellekson.com>
 * Kenyon Ralph <kenyon@kenyonralph.com>
+* Jeffrey Egeland <jegeland@vt.edu>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 Classification-Banner
 =====================
 
+<a href="https://scan.coverity.com/projects/securitycentral-classification-banner">
+  <img alt="Coverity Scan Build Status"
+       src="https://img.shields.io/coverity/scan/16706.svg"/>
+</a>
+
 Classification Banner is a python script that will display the
 classification level banner of a session with a variety of
 configuration options on the primary screen.  This script can
@@ -10,7 +15,7 @@ example PII or SECRET Material being processed in a graphical
 session. The script has been tested on a variety of graphical
 environments such as GNOME2, GNOME3, KDE, twm, icewm, and Cinnamon.
 
-Python script verified working on RHEL 5/6/7 and Fedora 12-28.
+Python script verified working on Red Hat Enterprise Linux and Fedora.
 
 Selecting the classification window and pressing the ESC key
 will temporarily hide the window for 15 seconds, it will return
@@ -18,6 +23,22 @@ to view after that
 
 Installation
 ============
+
+## Fedora
+`classification-banner` can be found in the Fedora repositories and installed
+via `dnf`:
+```sh
+dnf -y install classification-banner
+```
+
+## RHEL
+`classification-banner` can be found in the EPEL repositories and installed
+via `yum`:
+```sh
+yum -y install classification-banner
+```
+
+## Source
 To install directly from source, run the following command:
 ```sh
 python setup.py install
@@ -80,13 +101,14 @@ Labels as requisitioned from the U.S. Government Publishing Office (GPO)
 by the Federal Prison Industries (FPI) Unicor"; U.S. Government Publishing
 Office; 28 April 2016;
 
-https://www.gpo.gov/gpo/abstracts/getcontentpdf.action?filePath=Dallas%2Fab1724s.pdf
+https://www.gpo.gov/docs/default-source/contract-pricing/dallas/ab1724s.pdf
 
 SF-710: Pantone 356 - (Reverse printing) White on Green
 SF-708: Pantone 286 - (Reverse printing) White on Blue
 SF-707: Pantone 186 - (Reverse printing) White on Red
 SF-706: Pantone 165 - (Reverse printing) White on Orange
 SF-712: Pantone 101 - Black on Yellow
+SF-709: Pantone 264 - Black on Lavender
 
 The following are the approximate RGB and HEX values of the above Pantone
 Solid Coated values as provided by the Pantone website:
@@ -97,6 +119,7 @@ SF-708: RGB:   0,  51, 160 / HEX: #0033a0 | https://www.pantone.com/color-finder
 SF-707: RGB: 200,  16,  46 / HEX: #c8102e | https://www.pantone.com/color-finder/186-C
 SF-706: RGB: 255, 103,  31 / HEX: #ff671f | https://www.pantone.com/color-finder/165-C
 SF-712: RGB: 247, 234,  72 / HEX: #f7ea48 | https://www.pantone.com/color-finder/101-C
+SF-709: RGB: 193, 167, 226 / HEX: #c1a7e2 | https://www.pantone.com/color-finder/264-C
 
     Default (UNCLASSIFIED)
         
@@ -136,7 +159,7 @@ vi /etc/xdg/autostart/classification-banner.desktop
 
      [Desktop Entry]
      Name=Classification Banner
-     Exec=/usr/local/bin/classification-banner.py
+     Exec=/usr/bin/classification-banner.py
      Comment=User Notification for Security Level of System.
      Type=Application
      Encoding=UTF-8

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Classification-Banner
 Classification Banner is a python script that will display the
 classification level banner of a session with a variety of
 configuration options on the primary screen.  This script can
-help government and possibly private customers display a 
-notification that sensitive material is being displayed - for 
+help government and possibly private customers display a
+notification that sensitive material is being displayed - for
 example PII or SECRET Material being processed in a graphical
 session. The script has been tested on a variety of graphical
 environments such as GNOME2, GNOME3, KDE, twm, icewm, and Cinnamon.
@@ -89,7 +89,7 @@ based upon generally accepted color guidelines in the DoD/IC.
 Note: The U.S. General Services Administration (GSA) no longer publishes
 the color values used for printing U.S. Government Standard Forms (SF)
 such as the SF-710 (Unclassified Label), SF-708 (Confidential Label),
-SF-707 (Secret Label), SF-706 (Top Secret Label), or SF-712 (Classified 
+SF-707 (Secret Label), SF-706 (Top Secret Label), or SF-712 (Classified
 SCI Label): http://www.gsa.gov/portal/content/142623
 
 However, archived copies of superseded U.S. Government documents provide
@@ -122,36 +122,36 @@ SF-712: RGB: 247, 234,  72 / HEX: #f7ea48 | https://www.pantone.com/color-finder
 SF-709: RGB: 193, 167, 226 / HEX: #c1a7e2 | https://www.pantone.com/color-finder/264-C
 
     Default (UNCLASSIFIED)
-        
+
     CONFIDENTIAL
-    
+
         message='CONFIDENTIAL'
-	fgcolor='#FFFFFF'
+        fgcolor='#FFFFFF'
         bgcolor='#0033A0'
-    
+
     SECRET
-        
+
         message='SECRET'
         fgcolor='#FFFFFF'
         bgcolor='#C8102E'
-    
+
     TOP SECRET
-        
+
         message='TOP SECRET'
         fgcolor='#FFFFFF'
         bgcolor='#FF671F'
-        
+
     TOP SECRET//SCI
-        
+
         message='TOP SECRET//SCI'
-	fgcolor="#000000'
+        fgcolor="#000000'
         bgcolor='#F7EA48'
 ```
 
 Autostart
 =========
 
-To auto-start the classification-banner script on the GNOME Desktop, 
+To auto-start the classification-banner script on the GNOME Desktop,
 create the following file:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Note: The U.S. General Services Administration (GSA) no longer publishes
 the color values used for printing U.S. Government Standard Forms (SF)
 such as the SF-710 (Unclassified Label), SF-708 (Confidential Label),
 SF-707 (Secret Label), SF-706 (Top Secret Label), or SF-712 (Classified
-SCI Label): http://www.gsa.gov/portal/content/142623
+SCI Label): https://www.gsa.gov/colorstd
 
 However, archived copies of superseded U.S. Government documents provide
 the previously published Pantone values as well as a publicly available

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Classification-Banner
 
-<a href="https://scan.coverity.com/projects/securitycentral-classification-banner">
-  <img alt="Coverity Scan Build Status"
-       src="https://img.shields.io/coverity/scan/16706.svg"/>
-</a>
-
 Classification Banner is a python script that will display the
 classification level banner of a session with a variety of
 configuration options on the primary screen.  This script can
@@ -17,8 +12,8 @@ environments such as GNOME2, GNOME3, KDE, twm, icewm, and Cinnamon.
 Python script verified working on Red Hat Enterprise Linux and Fedora.
 
 Selecting the classification window and pressing the ESC key
-will temporarily hide the window for 15 seconds, it will return
-to view after that
+will temporarily hide the window for a configurable number of seconds,
+it will return to view after that
 
 # Installation
 
@@ -59,6 +54,7 @@ Options should be placed in the `/etc/classification-banner/banner.conf` file.
 * `sys_info` - Show user and hostname in the top banner (Default: `False`)
 * `opacity` - Sets opacity - for composted window managers only (OPTIONAL) [float - range 0 .. 1] (Default: `0.75`)
 * `esc` - Enable/Disable the 'ESC to hide' message (Default: `True` (enabled))
+* `esc_timeout` - Configure how long the 'ESC' key will hide the classification banner (Default: 15s)
 * `spanning` - Enable banner(s) to span across screens as a single banner (Default: `False`)
 
 Command line options that correspond to the above settings (use `classification-banner --help` for more information):

--- a/README.md
+++ b/README.md
@@ -109,24 +109,28 @@ Office; 28 April 2016;
 
 https://www.gpo.gov/docs/default-source/contract-pricing/dallas/ab1724s.pdf
 
-SF-710: Pantone 356 - (Reverse printing) White on Green
-SF-708: Pantone 286 - (Reverse printing) White on Blue
-SF-707: Pantone 186 - (Reverse printing) White on Red
-SF-706: Pantone 165 - (Reverse printing) White on Orange
-SF-712: Pantone 101 - Black on Yellow
-SF-709: Pantone 264 - Black on Lavender
+* SF-710: Pantone 356 - (Reverse printing) White on Green
+* SF-708: Pantone 286 - (Reverse printing) White on Blue
+* SF-707: Pantone 186 - (Reverse printing) White on Red
+* SF-706: Pantone 165 - (Reverse printing) White on Orange
+* SF-712: Pantone 101 - Black on Yellow
+* SF-709: Pantone 264 - Black on Lavender
 
-The following are the approximate RGB and HEX values of the above Pantone
+The following are the approximate RGB and hexadecimal values of the above Pantone
 Solid Coated values as provided by the Pantone website:
 
-```
-SF-710: RGB:   0, 122,  51 / HEX: #007a33 | https://www.pantone.com/color-finder/356-C
-SF-708: RGB:   0,  51, 160 / HEX: #0033a0 | https://www.pantone.com/color-finder/286-C
-SF-707: RGB: 200,  16,  46 / HEX: #c8102e | https://www.pantone.com/color-finder/186-C
-SF-706: RGB: 255, 103,  31 / HEX: #ff671f | https://www.pantone.com/color-finder/165-C
-SF-712: RGB: 247, 234,  72 / HEX: #f7ea48 | https://www.pantone.com/color-finder/101-C
-SF-709: RGB: 193, 167, 226 / HEX: #c1a7e2 | https://www.pantone.com/color-finder/264-C
+Pantone | RGB | Hex | Link
+--------|-----|-----|-----
+SF-710 |   0, 122,  51 | #007a33 | https://www.pantone.com/color-finder/356-C
+SF-708 |   0,  51, 160 | #0033a0 | https://www.pantone.com/color-finder/286-C
+SF-707 | 200,  16,  46 | #c8102e | https://www.pantone.com/color-finder/186-C
+SF-706 | 255, 103,  31 | #ff671f | https://www.pantone.com/color-finder/165-C
+SF-712 | 247, 234,  72 | #f7ea48 | https://www.pantone.com/color-finder/101-C
+SF-709 | 193, 167, 226 | #c1a7e2 | https://www.pantone.com/color-finder/264-C
 
+Examples from the default `banner.conf`:
+
+```
     Default (UNCLASSIFIED)
 
     CONFIDENTIAL

--- a/README.md
+++ b/README.md
@@ -50,39 +50,39 @@ Classification Banner Usage
 Options should be placed in the `/etc/classification-banner/banner.conf` file.
 
 ```
- message      - The classification level to display (Default: 'UNCLASSIFIED')
- foreground   - Foreground color of the text to display (Default: '#007A33' "Green")
- background   - Background color of the banner the text is against (Default: '#FFFFFF' "White")
- font         - Font face to use for the displayed text (Default: 'liberation-sans')
- size         - Size of font to use for text (Default: 'small')
- weight       - Bold or normal (Default: 'bold')
- show_top     - Show top banner (Default: True)
- show_bottom  - Show bottom banner (Default: True)
- horizontal_resolution         - Manually Set Horiztonal Resolution (OPTIONAL) [ if hres is set, vres required ]
- vertical_resolution           - Manually Set Horiztonal Resolution (OPTIONAL) [ if vres is set, hres required ]
- sys_info     - Show user and hostname in the top banner (Default: False)
- opacity      - Sets opacity - for composted window managers only (OPTIONAL) [float - range 0 .. 1] (Default 0.75)
- esc          - Enable/Disable the 'ESC to hide' message (Default: True (enabled))
- spanning     - Enable banner(s) to span across screens as a single banner (Default: False)
+message      - The classification level to display (Default: 'UNCLASSIFIED')
+foreground   - Foreground color of the text to display (Default: '#007A33' "Green")
+background   - Background color of the banner the text is against (Default: '#FFFFFF' "White")
+font         - Font face to use for the displayed text (Default: 'liberation-sans')
+size         - Size of font to use for text (Default: 'small')
+weight       - Bold or normal (Default: 'bold')
+show_top     - Show top banner (Default: True)
+show_bottom  - Show bottom banner (Default: True)
+horizontal_resolution         - Manually Set Horiztonal Resolution (OPTIONAL) [ if hres is set, vres required ]
+vertical_resolution           - Manually Set Horiztonal Resolution (OPTIONAL) [ if vres is set, hres required ]
+sys_info     - Show user and hostname in the top banner (Default: False)
+opacity      - Sets opacity - for composted window managers only (OPTIONAL) [float - range 0 .. 1] (Default 0.75)
+esc          - Enable/Disable the 'ESC to hide' message (Default: True (enabled))
+spanning     - Enable banner(s) to span across screens as a single banner (Default: False)
 ```
 
 Command line options that correspond to the above settings (use `classification-banner --help` for more information):
 
 ```
- -m, --message
- -f, --fgcolor
- -b, --bgcolor
- --font
- --size
- --weight
- --hide-top
- --hide-bottom
- -x, --hres
- -y, --vres
- --system-info
- -o, --opacity
- --disable-esc
- --enable-spanning
+-m, --message
+-f, --fgcolor
+-b, --bgcolor
+--font
+--size
+--weight
+--hide-top
+--hide-bottom
+-x, --hres
+-y, --vres
+--system-info
+-o, --opacity
+--disable-esc
+--enable-spanning
 ```
 
 Examples
@@ -131,31 +131,31 @@ SF-709 | 193, 167, 226 | #c1a7e2 | https://www.pantone.com/color-finder/264-C
 Examples from the default `banner.conf`:
 
 ```
-    Default (UNCLASSIFIED)
+Default (UNCLASSIFIED)
 
-    CONFIDENTIAL
+CONFIDENTIAL
 
-        message='CONFIDENTIAL'
-        foreground='#FFFFFF'
-        background='#0033A0'
+    message='CONFIDENTIAL'
+    foreground='#FFFFFF'
+    background='#0033A0'
 
-    SECRET
+SECRET
 
-        message='SECRET'
-        foreground='#FFFFFF'
-        background='#C8102E'
+    message='SECRET'
+    foreground='#FFFFFF'
+    background='#C8102E'
 
-    TOP SECRET
+TOP SECRET
 
-        message='TOP SECRET'
-        foreground='#FFFFFF'
-        background='#FF671F'
+    message='TOP SECRET'
+    foreground='#FFFFFF'
+    background='#FF671F'
 
-    TOP SECRET//SCI
+TOP SECRET//SCI
 
-        message='TOP SECRET//SCI'
-        foreground="#000000'
-        background='#F7EA48'
+    message='TOP SECRET//SCI'
+    foreground="#000000'
+    background='#F7EA48'
 ```
 
 Autostart
@@ -166,16 +166,16 @@ create the file `/etc/xdg/autostart/classification-banner.desktop`
 with the following contents:
 
 ```ini
-     [Desktop Entry]
-     Name=Classification Banner
-     Exec=/usr/bin/classification-banner
-     Comment=User Notification for Security Level of System.
-     Type=Application
-     Encoding=UTF-8
-     Version=1.0
-     MimeType=application/python;
-     Categories=Utility;
-     X-GNOME-Autostart-enabled=true
-     StartupNotify=false
-     Terminal=false
+[Desktop Entry]
+Name=Classification Banner
+Exec=/usr/bin/classification-banner
+Comment=User Notification for Security Level of System.
+Type=Application
+Encoding=UTF-8
+Version=1.0
+MimeType=application/python;
+Categories=Utility;
+X-GNOME-Autostart-enabled=true
+StartupNotify=false
+Terminal=false
 ```

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ python setup.py install
 Options should be placed in the `/etc/classification-banner/banner.conf` file.
 
 * `message` - The classification level to display (Default: `UNCLASSIFIED`)
-* `foreground` - Foreground color of the text to display (Default: `#007A33` "Green")
-* `background` - Background color of the banner the text is against (Default: `#FFFFFF` "White")
+* `foreground` - Foreground color of the text to display (Default: `#FFFFFF` "White")
+* `background` - Background color of the banner the text is against (Default: `#007A33` "Green")
 * `font` - Font face to use for the displayed text (Default: `liberation-sans`)
 * `size` - Size of font to use for text (Default: `small`)
 * `weight` - Bold or normal (Default: `bold`)

--- a/README.md
+++ b/README.md
@@ -162,11 +162,10 @@ Autostart
 =========
 
 To auto-start the classification-banner script on the GNOME Desktop,
-create the following file:
+create the file `/etc/xdg/autostart/classification-banner.desktop`
+with the following contents:
 
-```sh
-vi /etc/xdg/autostart/classification-banner.desktop
-
+```ini
      [Desktop Entry]
      Name=Classification Banner
      Exec=/usr/bin/classification-banner

--- a/README.md
+++ b/README.md
@@ -51,16 +51,19 @@ Options should be placed in the `/etc/classification-banner/banner.conf` file.
 
 ```
  message      - The classification level to display (Default: 'UNCLASSIFIED')
- foreground_color      - Foreground color of the text to display (Default: '#007A33' "Green")
- background_color      - Background color of the banner the text is against (Default: '#FFFFFF' "White")
- face         - Font face to use for the displayed text (Default: 'liberation-sans')
+ foreground   - Foreground color of the text to display (Default: '#007A33' "Green")
+ background   - Background color of the banner the text is against (Default: '#FFFFFF' "White")
+ font         - Font face to use for the displayed text (Default: 'liberation-sans')
  size         - Size of font to use for text (Default: 'small')
  weight       - Bold or normal (Default: 'bold')
  show_top     - Show top banner (Default: True)
  show_bottom  - Show bottom banner (Default: True)
  horizontal_resolution         - Manually Set Horiztonal Resolution (OPTIONAL) [ if hres is set, vres required ]
  vertical_resolution           - Manually Set Horiztonal Resolution (OPTIONAL) [ if vres is set, hres required ]
+ sys_info     - Show user and hostname in the top banner (Default: False)
  opacity      - Sets opacity - for composted window managers only (OPTIONAL) [float - range 0 .. 1] (Default 0.75)
+ esc          - Enable/Disable the 'ESC to hide' message (Default: True (enabled))
+ spanning     - Enable banner(s) to span across screens as a single banner (Default: False)
 ```
 
 Command line options that correspond to the above settings:
@@ -69,14 +72,17 @@ Command line options that correspond to the above settings:
  -m, --message
  -f, --fgcolor
  -b, --bgcolor
- --face
+ --font
  --size
  --weight
  --hide-top
  --hide-bottom
  -x, --hres
  -y, --vres
+ --system-info
  -o, --opacity
+ --disable-esc
+ --enable-spanning
 ```
 
 Examples
@@ -126,26 +132,26 @@ SF-709: RGB: 193, 167, 226 / HEX: #c1a7e2 | https://www.pantone.com/color-finder
     CONFIDENTIAL
 
         message='CONFIDENTIAL'
-        fgcolor='#FFFFFF'
-        bgcolor='#0033A0'
+        foreground='#FFFFFF'
+        background='#0033A0'
 
     SECRET
 
         message='SECRET'
-        fgcolor='#FFFFFF'
-        bgcolor='#C8102E'
+        foreground='#FFFFFF'
+        background='#C8102E'
 
     TOP SECRET
 
         message='TOP SECRET'
-        fgcolor='#FFFFFF'
-        bgcolor='#FF671F'
+        foreground='#FFFFFF'
+        background='#FF671F'
 
     TOP SECRET//SCI
 
         message='TOP SECRET//SCI'
-        fgcolor="#000000'
-        bgcolor='#F7EA48'
+        foreground="#000000'
+        background='#F7EA48'
 ```
 
 Autostart
@@ -159,7 +165,7 @@ vi /etc/xdg/autostart/classification-banner.desktop
 
      [Desktop Entry]
      Name=Classification Banner
-     Exec=/usr/bin/classification-banner.py
+     Exec=/usr/bin/classification-banner
      Comment=User Notification for Security Level of System.
      Type=Application
      Encoding=UTF-8

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Classification-Banner
-=====================
+# Classification-Banner
 
 <a href="https://scan.coverity.com/projects/securitycentral-classification-banner">
   <img alt="Coverity Scan Build Status"
@@ -21,8 +20,7 @@ Selecting the classification window and pressing the ESC key
 will temporarily hide the window for 15 seconds, it will return
 to view after that
 
-Installation
-============
+# Installation
 
 ## Fedora
 `classification-banner` can be found in the Fedora repositories and installed
@@ -44,27 +42,24 @@ To install directly from source, run the following command:
 python setup.py install
 ```
 
-Classification Banner Usage
-===========================
+# Classification Banner Usage
 
 Options should be placed in the `/etc/classification-banner/banner.conf` file.
 
-```
-message      - The classification level to display (Default: 'UNCLASSIFIED')
-foreground   - Foreground color of the text to display (Default: '#007A33' "Green")
-background   - Background color of the banner the text is against (Default: '#FFFFFF' "White")
-font         - Font face to use for the displayed text (Default: 'liberation-sans')
-size         - Size of font to use for text (Default: 'small')
-weight       - Bold or normal (Default: 'bold')
-show_top     - Show top banner (Default: True)
-show_bottom  - Show bottom banner (Default: True)
-horizontal_resolution         - Manually Set Horiztonal Resolution (OPTIONAL) [ if hres is set, vres required ]
-vertical_resolution           - Manually Set Horiztonal Resolution (OPTIONAL) [ if vres is set, hres required ]
-sys_info     - Show user and hostname in the top banner (Default: False)
-opacity      - Sets opacity - for composted window managers only (OPTIONAL) [float - range 0 .. 1] (Default 0.75)
-esc          - Enable/Disable the 'ESC to hide' message (Default: True (enabled))
-spanning     - Enable banner(s) to span across screens as a single banner (Default: False)
-```
+* `message` - The classification level to display (Default: `UNCLASSIFIED`)
+* `foreground` - Foreground color of the text to display (Default: `#007A33` "Green")
+* `background` - Background color of the banner the text is against (Default: `#FFFFFF` "White")
+* `font` - Font face to use for the displayed text (Default: `liberation-sans`)
+* `size` - Size of font to use for text (Default: `small`)
+* `weight` - Bold or normal (Default: `bold`)
+* `show_top` - Show top banner (Default: `True`)
+* `show_bottom` - Show bottom banner (Default: `True`)
+* `horizontal_resolution` - Manually Set Horiztonal Resolution (OPTIONAL) [if hres is set, vres required]
+* `vertical_resolution` - Manually Set Horiztonal Resolution (OPTIONAL) [if vres is set, hres required]
+* `sys_info` - Show user and hostname in the top banner (Default: `False`)
+* `opacity` - Sets opacity - for composted window managers only (OPTIONAL) [float - range 0 .. 1] (Default: `0.75`)
+* `esc` - Enable/Disable the 'ESC to hide' message (Default: `True` (enabled))
+* `spanning` - Enable banner(s) to span across screens as a single banner (Default: `False`)
 
 Command line options that correspond to the above settings (use `classification-banner --help` for more information):
 
@@ -85,8 +80,7 @@ Command line options that correspond to the above settings (use `classification-
 --enable-spanning
 ```
 
-Examples
-========
+# Examples
 
 These are examples for the configuration of the Classification Banner
 using the `/etc/classification-banner/banner.conf` file for various classifications
@@ -128,38 +122,49 @@ SF-706 | 255, 103,  31 | #ff671f | https://www.pantone.com/color-finder/165-C
 SF-712 | 247, 234,  72 | #f7ea48 | https://www.pantone.com/color-finder/101-C
 SF-709 | 193, 167, 226 | #c1a7e2 | https://www.pantone.com/color-finder/264-C
 
-Examples from the default `banner.conf`:
+## Examples from the default `banner.conf`:
+
+### UNCLASSIFIED (Default)
 
 ```
-Default (UNCLASSIFIED)
-
-CONFIDENTIAL
-
-    message='CONFIDENTIAL'
-    foreground='#FFFFFF'
-    background='#0033A0'
-
-SECRET
-
-    message='SECRET'
-    foreground='#FFFFFF'
-    background='#C8102E'
-
-TOP SECRET
-
-    message='TOP SECRET'
-    foreground='#FFFFFF'
-    background='#FF671F'
-
-TOP SECRET//SCI
-
-    message='TOP SECRET//SCI'
-    foreground="#000000'
-    background='#F7EA48'
+message = UNCLASSIFIED
+foreground = #FFFFFF
+background = #007A33
 ```
 
-Autostart
-=========
+### CONFIDENTIAL
+
+```
+message = CONFIDENTIAL
+foreground = #FFFFFF
+background = #0033A0
+```
+
+### SECRET
+
+```
+message = SECRET
+foreground = #FFFFFF
+background = #C8102E
+```
+
+### TOP SECRET
+
+```
+message = TOP SECRET
+foreground = #FFFFFF
+background = #FF671F
+```
+
+### TOP SECRET//SCI
+
+```
+message = TOP SECRET//SCI
+foreground = #000000
+background = #F7EA48
+```
+
+# Autostart
 
 To auto-start the classification-banner script on the GNOME Desktop,
 create the file `/etc/xdg/autostart/classification-banner.desktop`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dnf -y install classification-banner
 ```
 
 ## RHEL
-`classification-banner` can be found in the EPEL repositories and installed
+`classification-banner` can be found in the [EPEL](https://fedoraproject.org/wiki/EPEL) repositories and installed
 via `yum`:
 ```sh
 yum -y install classification-banner

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Options should be placed in the `/etc/classification-banner/banner.conf` file.
  spanning     - Enable banner(s) to span across screens as a single banner (Default: False)
 ```
 
-Command line options that correspond to the above settings:
+Command line options that correspond to the above settings (use `classification-banner --help` for more information):
 
 ```
  -m, --message

--- a/classification-banner.spec
+++ b/classification-banner.spec
@@ -1,0 +1,75 @@
+Name:           classification-banner
+Version:        1.6.7
+Release:        2%{?dist}
+Summary:        Displays Classification Banner for a Graphical Session
+
+License:        GPLv2+
+URL:            https://github.com/millennialsoftware/classification-banner
+Source0:        %{URL}/archive/%{version}/%{name}-%{version}.tar.gz
+
+BuildArch:      noarch
+BuildRequires:  python2-setuptools
+BuildRequires:  python2-devel
+BuildRequires:  pygtk2
+BuildRequires:  pygobject2
+BuildRequires:  desktop-file-utils
+Requires:       xorg-x11-server-utils
+Requires:       pygtk2
+Requires:       pygobject2
+
+%description
+Classification Banner is a python script that will display the
+classification level banner of a session with a variety of
+configuration options on the primary screen.  This script can
+help government and possibly private customers display a 
+notification that sensitive material is being displayed - for 
+example PII or SECRET Material being processed in a graphical
+session. The script has been tested on a variety of graphical
+environments such as GNOME2, GNOME3, KDE, twm, icewm, and Cinnamon.
+
+%prep
+%autosetup -p1
+
+%build
+%py2_build
+
+%install
+%py2_install
+
+install -d -m755 %{buildroot}%{_datadir}/%{name}
+install -d -m755 %{buildroot}%{_sysconfdir}/%{name}
+install -d -m755 %{buildroot}%{_sysconfdir}/xdg/autostart/
+
+install -pm644 contrib/banner.conf %{buildroot}%{_sysconfdir}/%{name}/banner.conf
+install -pm644 share/%{name}-screenshot.png %{buildroot}%{_datadir}/%{name}/%{name}-screenshot.png
+
+desktop-file-install \
+--dir=%{buildroot}%{_sysconfdir}/xdg/autostart \
+contrib/%{name}.desktop
+
+%check
+%{__python2} setup.py test
+
+%post
+/usr/bin/update-desktop-database &> /dev/null || :
+
+%postun
+/usr/bin/update-desktop-database &> /dev/null || :
+
+%files
+%license LICENSE
+%doc README.md AUTHOR Contributors.md
+%{python2_sitelib}/classification_banner
+%{python2_sitelib}/classification_banner-%{version}-py?.?.egg-info
+
+%config(noreplace) %{_sysconfdir}/%{name}/banner.conf
+%config(noreplace) %{_sysconfdir}/xdg/autostart/classification-banner.desktop
+%{_bindir}/%{name}
+%{_datadir}/%{name}/%{name}-screenshot.png
+
+%changelog
+* Wed Feb 13 2019 Gabe <redhatrises@gmail.com> - 1.6.7-2
+- Fix booleans being read as strings from banner.conf (rhbz#1669155)
+
+* Thu Aug 9 2018 Gabe <redhatrises@gmail.com> - 1.6.7-1
+- First package for EPEL

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 SecurityCentral Contributors. See LICENSE for license
+# Copyright (C) 2022 SecurityCentral Contributors. See LICENSE for license
 #
 
 """Python Scritp to display classification level banner of a session"""
@@ -9,6 +9,7 @@ import sys
 import os
 import argparse
 import time
+import re
 from ConfigParser import SafeConfigParser
 from socket import gethostname
 
@@ -254,7 +255,14 @@ class DisplayBanner:  # pylint: disable=old-style-class,too-many-instance-attrib
         conf = SafeConfigParser()
         conf.read(CONF_FILE)
         for key, val in conf.items("global"):
-            defaults[key] = val
+            if re.match(r"^[0-9]+$", val):
+                defaults[key] = conf.getint("global", key)
+            elif re.match(r"^[0-9]+.[0-9]+$", val):
+                defaults[key] = conf.getfloat("global", key)
+            elif re.match(r"^(true|false|yes|no)$", val, re.IGNORECASE):
+                defaults[key] = conf.getboolean("global", key)
+            else:
+                defaults[key] = val
 
         # Use the global config to set defaults for command line options
         parser = argparse.ArgumentParser()

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2018 SecurityCentral Contributors. See LICENSE for license
 #
 
+"""Python Scritp to display classification level banner of a session"""
+
+from __future__ import print_function
 import sys
 import os
 import argparse
@@ -15,7 +18,7 @@ CONF_FILE = "/etc/classification-banner/banner.conf"
 # Check if DISPLAY variable is set
 try:
     os.environ["DISPLAY"]
-except:
+except OSError:
     print("Error: DISPLAY environment variable is not set.")
     sys.exit(1)
 
@@ -25,32 +28,34 @@ try:
 except ImportError:
     try:
         import Gtk
-    except ImportError as e:
-        raise(e)
+    except ImportError as err:
+        raise err
 
 
 # Returns Username
 def get_user():
+    """Returns Username"""
     try:
         user = os.getlogin()
-    except:
+    except OSError:
         user = ''
-        pass
+
     return user
 
 
 # Returns Hostname
 def get_host():
+    """Returns Hostname"""
     host = gethostname()
     host = host.split('.')[0]
     return host
 
 
 # Classification Banner Class
-class Classification_Banner:
+class ClassificationBanner:  # pylint: disable=too-many-instance-attributes,old-style-class
     """Class to create and refresh the actual banner."""
 
-    def __init__(self, message="UNCLASSIFIED", fgcolor="#000000",
+    def __init__(self, message="UNCLASSIFIED", fgcolor="#000000",   # pylint: disable=invalid-name,too-many-arguments,too-many-statements
                  bgcolor="#00CC00", font="liberation-sans", size="small",
                  weight="bold", x=0, y=0, esc=True, opacity=0.75,
                  sys_info=False):
@@ -78,7 +83,7 @@ class Classification_Banner:
         # Newer versions of pygtk have this method
         try:
             self.monitor.connect("monitors-changed", self.resize)
-        except:
+        except AttributeError:
             pass
 
         # Create Main Window
@@ -97,7 +102,7 @@ class Classification_Banner:
 
         try:
             self.window.set_opacity(opacity)
-        except:
+        except AttributeError:  # nosec
             pass
 
         # Set the default window size
@@ -136,7 +141,7 @@ class Classification_Banner:
         # Create the Right-Justified Vertical Box to Populate for ESC message
         self.vbox_esc_right = gtk.VBox()
         self.esc_label = gtk.Label(
-            "<span font_family='liberation-sans' weight='normal' foreground='%s' size='xx-small'>  (ESC to hide temporarily)  </span>" %
+            "<span font_family='liberation-sans' weight='normal' foreground='%s' size='xx-small'>  (ESC to hide temporarily)  </span>" %  # pylint: disable=line-too-long
             (fgcolor))
         self.esc_label.set_use_markup(True)
         self.esc_label.set_justify(gtk.JUSTIFY_RIGHT)
@@ -169,31 +174,34 @@ class Classification_Banner:
                 self.hbox.pack_start(self.vbox_empty, False, True, 0)
 
         if sys_info:
-                self.vbox_right.pack_start(self.host_label, True, True, 0)
-                self.vbox_left.pack_start(self.user_label, True, True, 0)
-                self.hbox.pack_start(self.vbox_right, False, True, 20)
-                self.hbox.pack_start(self.vbox_center, True, True, 0)
-                self.hbox.pack_start(self.vbox_left, False, True, 20)
+            self.vbox_right.pack_start(self.host_label, True, True, 0)
+            self.vbox_left.pack_start(self.user_label, True, True, 0)
+            self.hbox.pack_start(self.vbox_right, False, True, 20)
+            self.hbox.pack_start(self.vbox_center, True, True, 0)
+            self.hbox.pack_start(self.vbox_left, False, True, 20)
 
         self.window.add(self.hbox)
         self.window.show_all()
         self.width, self.height = self.window.get_size()
 
     # Restore Minimized Window
-    def restore(self, widget, data=None):
+    def restore(self, widget, data=None):  # pylint: disable=unused-argument
+        """Restore Minimized Window"""
         self.window.deiconify()
         self.window.present()
 
         return True
 
     # Destroy Classification Banner Window on Resize (Display Banner Will Relaunch)
-    def resize(self, widget, data=None):
+    def resize(self, widget, data=None):  # pylint: disable=unused-argument
+        """Destroy Classification Banner Window on Resize (Display Banner Will Relaunch)"""
         self.window.destroy()
 
         return True
 
     # Press ESC to hide window for 15 seconds
-    def keypress(self, widget, event=None):
+    def keypress(self, widget, event=None):  # pylint: disable=unused-argument
+        """Press ESC to hide window for 15 seconds"""
         if event.keyval == 65307:
             if not gtk.events_pending():
                 self.window.iconify()
@@ -206,9 +214,9 @@ class Classification_Banner:
         return True
 
 
-class Display_Banner:
-
+class DisplayBanner:  # pylint: disable=old-style-class,too-many-instance-attributes
     """Display Classification Banner Message"""
+
     def __init__(self):
         # Dynamic Resolution Scaling
         self.monitor = gtk.gdk.Screen()
@@ -217,7 +225,7 @@ class Display_Banner:
         # Newer versions of pygtk have this method
         try:
             self.monitor.connect("monitors-changed", self.resize)
-        except:
+        except AttributeError:
             pass
 
         # Launch Banner
@@ -226,6 +234,7 @@ class Display_Banner:
 
     # Read Global configuration
     def configure(self):
+        """Read Global configuration"""
         defaults = {}
         defaults["message"] = "UNCLASSIFIED"
         defaults["foreground"] = "#FFFFFF"
@@ -250,37 +259,37 @@ class Display_Banner:
         # Use the global config to set defaults for command line options
         parser = argparse.ArgumentParser()
         parser.add_argument("-m", "--message", default=defaults["message"],
-                          help="Set the Classification message")
+                            help="Set the Classification message")
         parser.add_argument("-f", "--fgcolor", default=defaults["foreground"],
-                          help="Set the Foreground (text) color")
+                            help="Set the Foreground (text) color")
         parser.add_argument("-b", "--bgcolor", default=defaults["background"],
-                          help="Set the Background color")
+                            help="Set the Background color")
         parser.add_argument("-x", "--hres", default=defaults["horizontal_resolution"], type=int,
-                          help="Set the Horizontal Screen Resolution")
+                            help="Set the Horizontal Screen Resolution")
         parser.add_argument("-y", "--vres", default=defaults["vertical_resolution"], type=int,
-                          help="Set the Vertical Screen Resolution")
+                            help="Set the Vertical Screen Resolution")
         parser.add_argument("-o", "--opacity", default=defaults["opacity"],
-                          type=float, dest="opacity",
-                          help="Set the window opacity for composted window managers")
+                            type=float, dest="opacity",
+                            help="Set the window opacity for composted window managers")
         parser.add_argument("--font", default=defaults["font"], help="Font type")
         parser.add_argument("--size", default=defaults["size"], help="Font size")
         parser.add_argument("--weight", default=defaults["weight"],
-                          help="Set the Font weight")
+                            help="Set the Font weight")
         parser.add_argument("--disable-esc", default=defaults["esc"],
-                          dest="esc", action="store_false",
-                          help="Disable the 'ESC to hide' message")
+                            dest="esc", action="store_false",
+                            help="Disable the 'ESC to hide' message")
         parser.add_argument("--hide-top", default=defaults["show_top"],
-                          dest="show_top", action="store_false",
-                          help="Disable the top banner")
+                            dest="show_top", action="store_false",
+                            help="Disable the top banner")
         parser.add_argument("--hide-bottom", default=defaults["show_bottom"],
-                          dest="show_bottom", action="store_false",
-                          help="Disable the bottom banner")
+                            dest="show_bottom", action="store_false",
+                            help="Disable the bottom banner")
         parser.add_argument("--system-info", default=defaults["sys_info"],
-                          dest="sys_info", action="store_true",
-                          help="Show user and hostname in the top banner")
+                            dest="sys_info", action="store_true",
+                            help="Show user and hostname in the top banner")
         parser.add_argument("--enable-spanning", default=defaults["spanning"],
-                          dest="spanning", action="store_true",
-                          help="Enable banner(s) to span across screens as a single banner")
+                            dest="spanning", action="store_true",
+                            help="Enable banner(s) to span across screens as a single banner")
 
         args = parser.parse_args()
 
@@ -288,23 +297,24 @@ class Display_Banner:
 
     # Launch the Classification Banner Window(s)
     def execute(self, options):
+        """Launch the Classification Banner Window(s)"""
         self.num_monitor = 0
 
         if options.hres == 0 or options.vres == 0:
             # Try Xrandr to determine primary monitor resolution
             try:
                 self.screen = os.popen("xrandr | grep ' connected ' | awk '{ print $3 }'").readlines()[0]
-                self.x = self.screen.split('x')[0]
-                self.y = self.screen.split('x')[1].split('+')[0]
+                self.x = self.screen.split('x')[0]  # pylint: disable=invalid-name
+                self.y = self.screen.split('x')[1].split('+')[0]  # pylint: disable=invalid-name
 
-            except:
+            except IndexError:
                 try:
                     self.screen = os.popen("xrandr | grep ' current ' | awk '{ print $8$9$10+0 }'").readlines()[0]
                     self.x = self.screen.split('x')[0]
                     self.y = self.screen.split('x')[1].split('+')[0]
 
-                except:
-                    self.screen = os.popen("xrandr | grep '^\*0' | awk '{ print $2$3$4 }'").readlines()[0]
+                except IndexError:
+                    self.screen = os.popen("xrandr | grep '^\*0' | awk '{ print $2$3$4 }'").readlines()[0]  # pylint: disable=anomalous-backslash-in-string
                     self.x = self.screen.split('x')[0]
                     self.y = self.screen.split('x')[1].split('+')[0]
 
@@ -330,43 +340,46 @@ class Display_Banner:
             self.banners(options)
 
     def banners(self, options):
-            if options.show_top:
-                top = Classification_Banner(
-                    options.message,
-                    options.fgcolor,
-                    options.bgcolor,
-                    options.font,
-                    options.size,
-                    options.weight,
-                    self.x,
-                    self.y,
-                    options.esc,
-                    options.opacity,
-                    options.sys_info)
-                top.window.move(self.x_location, self.y_location)
+        """Set banner configuration"""
+        if options.show_top:
+            top = ClassificationBanner(
+                options.message,
+                options.fgcolor,
+                options.bgcolor,
+                options.font,
+                options.size,
+                options.weight,
+                self.x,
+                self.y,
+                options.esc,
+                options.opacity,
+                options.sys_info)
+            top.window.move(self.x_location, self.y_location)
 
-            if options.show_bottom:
-                bottom = Classification_Banner(
-                    options.message,
-                    options.fgcolor,
-                    options.bgcolor,
-                    options.font,
-                    options.size,
-                    options.weight,
-                    self.x,
-                    self.y,
-                    options.esc,
-                    options.opacity)
-                bottom.window.move(self.x_location, int(bottom.vres))
+        if options.show_bottom:
+            bottom = ClassificationBanner(
+                options.message,
+                options.fgcolor,
+                options.bgcolor,
+                options.font,
+                options.size,
+                options.weight,
+                self.x,
+                self.y,
+                options.esc,
+                options.opacity)
+            bottom.window.move(self.x_location, int(bottom.vres))
 
     # Relaunch the Classification Banner on Screen Resize
-    def resize(self, widget, data=None):
-        self.config, self.args = self.configure()
+    def resize(self, widget, data=None):  # pylint: disable=unused-argument
+        """Relaunch the Classification Banner on Screen Resize"""
+        self.config = self.configure()
         self.execute(self.config)
 
         return True
 
 
 def main():
-    run = Display_Banner()
+    """Display Banner"""
+    DisplayBanner()
     gtk.main()

--- a/contrib/banner.conf
+++ b/contrib/banner.conf
@@ -72,5 +72,8 @@ opacity = 0.75
 ## Enable/Disable the 'ESC to hide' message
 esc = True
 
+## Set the timeout for how long the banner will be hidden for when `ESC` is pressed (Default 15s)
+esc_timeout = 15
+
 ## Enable banner(s) to span across screens as a single banner
 spanning = False

--- a/contrib/banner.conf
+++ b/contrib/banner.conf
@@ -1,33 +1,37 @@
 [global]
 ## These are examples for the configuration of the Classification Banner
-## using the `/etc/classification-banner/banner.conf` file for various classifications
+## using the /etc/classification-banner/banner.conf file for various classifications
 ## based upon generally accepted color guidelines in the DoD/IC.
 ##
-##    Default (UNCLASSIFIED)
+##    UNCLASSIFIED (Default)
+##
+##        message = UNCLASSIFIED
+##        foreground = #FFFFFF
+##        background = #007A33
 ##
 ##    CONFIDENTIAL
 ##
-##        message='CONFIDENTIAL'
-##        fgcolor='#FFFFFF'
-##        bgcolor='#0033A0'
+##        message = CONFIDENTIAL
+##        foreground = #FFFFFF
+##        background = #0033A0
 ##
 ##    SECRET
 ##
-##        message='SECRET'
-##        fgcolor='#FFFFFF'
-##        bgcolor='#C8102E'
+##        message = SECRET
+##        foreground = #FFFFFF
+##        background = #C8102E
 ##
 ##    TOP SECRET
 ##
-##        message='TOP SECRET'
-##        fgcolor='#FFFFFF'
-##        bgcolor='#FF671F'
+##        message = TOP SECRET
+##        foreground = #FFFFFF
+##        background = #FF671F
 ##
 ##    TOP SECRET//SCI
 ##
-##        message='TOP SECRET//SCI'
-##        fgcolor="#000000'
-##        bgcolor='#F7EA48'
+##        message = TOP SECRET//SCI
+##        foreground = #000000
+##        background = #F7EA48
 ##
 ## The classification level to display (Default: 'UNCLASSIFIED')
 message = UNCLASSIFIED

--- a/contrib/banner.conf
+++ b/contrib/banner.conf
@@ -36,10 +36,10 @@
 ## The classification level to display (Default: 'UNCLASSIFIED')
 message = UNCLASSIFIED
 
-## Foreground color of the text to display (Default: '#007A33' "Green")
+## Foreground color of the text to display (Default: '#FFFFFF' "White")
 foreground = #FFFFFF
 
-## Background color of the banner the text is against (Default: '#FFFFFF' "White")
+## Background color of the banner the text is against (Default: '#007A33' "Green")
 background = #007A33
 
 ## Font type to use for the displayed text (Default: 'liberation-sans')

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 VERSION = "1.6.7"
 
 PACKAGE_VERSION = {
-    "classification-banner": "classification-banner == {}".format(VERSION),
+    "classification-banner": "classification-banner == {0}".format(VERSION),
 }
 
 
@@ -17,8 +17,8 @@ setup(
     long_description="""Classification Banner is a python script that will display the
 classification level banner of a session with a variety of
 configuration options on the primary screen.  This script can
-help government and possibly private customers display a 
-notification that sensitive material is being displayed - for 
+help government and possibly private customers display a
+notification that sensitive material is being displayed - for
 example PII or SECRET Material being processed in a graphical
 session. The script has been tested on a variety of graphical
 environments such as GNOME2, GNOME3, KDE, twm, icewm, and Cinnamon.""",


### PR DESCRIPTION
- Cherry-picked several doc cleanup commits from upstream.
- Fixed boolean vars in config not being respected
- Made the hidden banner timeout configurable
- Fixed spanning the banners over multiple monitors

Tested and validated on Centos 7.9 with kernel 3.10.0-1160.71.1.el7.x86_64