### PR TITLE
Change Default to NOT CONFIGURED

### DIFF
--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -49,9 +49,9 @@ def get_host():
 def configure():
     """Read Global configuration"""
     defaults = {}
-    defaults["message"] = "UNCLASSIFIED"
-    defaults["foreground"] = "#FFFFFF"
-    defaults["background"] = "#007A33"
+    defaults["message"] = "NOT CONFIGURED"
+    defaults["foreground"] = "#000000"
+    defaults["background"] = "#FFFFFF"
     defaults["font"] = "liberation-sans"
     defaults["size"] = "small"
     defaults["weight"] = "bold"


### PR DESCRIPTION
This change prevents a non-configured system to be unintentionally defined as UNCLASSIFIED.  This potentially leads to confusion of classification of the system during development/deployment.

White background and black text matches the defaults of the netbanner software in windows which has a similar purpose.