### PR TITLE
Fix "ESC to hide" functionality

### DIFF
--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -160,12 +160,7 @@ class ClassificationBanner:
         # Dynamic Resolution Scaling
         self.monitor = Gdk.Screen()
         self.monitor.connect("size-changed", self.resize)
-
-        # Newer versions of pygtk have this method
-        try:
-            self.monitor.connect("monitors-changed", self.resize)
-        except AttributeError:
-            pass
+        self.monitor.connect("monitors-changed", self.resize)
 
         # Create Main Window
         self.window = Gtk.Window()
@@ -333,15 +328,10 @@ class DisplayBanner:
         """Dynamic Resolution Scaling"""
         self.monitor = Gdk.Screen()
         self.monitor.connect("size-changed", self.resize)
+        self.monitor.connect("monitors-changed", self.resize)
 
         self.display = Gdk.Display.get_default()
         self.screen = self.display.get_default_screen()
-
-        # Newer versions of pygtk have this method
-        try:
-            self.monitor.connect("monitors-changed", self.resize)
-        except AttributeError:
-            pass
 
         # Launch Banner
         self.config = configure()

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -274,7 +274,7 @@ class ClassificationBanner:
         if isinstance(widget, Gtk.Container):
             widget.forall(self.apply_css, provider)
 
-    def restore(self):
+    def restore(self, *_):
         """Restore Minimized Window"""
         self.window.deiconify()
         self.window.present()
@@ -287,7 +287,7 @@ class ClassificationBanner:
 
         return True
 
-    def keypress(self, event=None):
+    def keypress(self, widget=None, event=None):
         """Press ESC to hide window for 15 seconds"""
         if event.keyval == 65307:
             if not Gtk.events_pending():

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -172,6 +172,7 @@ class ClassificationBanner:
         self.window.set_position(Gtk.WindowPosition.CENTER)
         self.window.connect("hide", self.restore)
         self.window.connect("key-press-event", self.keypress)
+        self.window.connect("window-state-event", self.stay_on_top)
         self.window.set_property('skip-taskbar-hint', True)
         self.window.set_property('skip-pager-hint', True)
         self.window.set_property('destroy-with-parent', True)
@@ -315,6 +316,13 @@ class ClassificationBanner:
                 self.window.hide()
                 GLib.timeout_add(15000, self._restore)
 
+        return True
+
+    def stay_on_top(self, _widget, event):
+        """Restore `ABOVE` state if lost"""
+        if event.new_window_state & Gdk.WindowState.ABOVE == 0:
+            # Window has lost above state, restore it
+            self.window.set_keep_above(True)
         return True
 
 

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -77,7 +77,6 @@ def configure():
             else:
                 defaults[key] = val
 
-    print(defaults["sys_info"])
     # Use the global config to set defaults for command line options
     parser = argparse.ArgumentParser()
     parser.add_argument("-m", "--message", default=defaults["message"],

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -66,15 +66,16 @@ def configure():
 
     conf = configparser.ConfigParser()
     conf.read(CONF_FILE)
-    for key, val in conf.items("global"):
-        if re.match(r"^[0-9]+$", val):
-            defaults[key] = conf.getint("global", key)
-        elif re.match(r"^[0-9]+.[0-9]+$", val):
-            defaults[key] = conf.getfloat("global", key)
-        elif re.match(r"^(true|false|yes|no)$", val, re.IGNORECASE):
-            defaults[key] = conf.getboolean("global", key)
-        else:
-            defaults[key] = val
+    if conf.has_section("global"):
+        for key, val in conf.items("global"):
+            if re.match(r"^[0-9]+$", val):
+                defaults[key] = conf.getint("global", key)
+            elif re.match(r"^[0-9]+.[0-9]+$", val):
+                defaults[key] = conf.getfloat("global", key)
+            elif re.match(r"^(true|false|yes|no)$", val, re.IGNORECASE):
+                defaults[key] = conf.getboolean("global", key)
+            else:
+                defaults[key] = val
 
     print(defaults["sys_info"])
     # Use the global config to set defaults for command line options

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -285,7 +285,7 @@ class ClassificationBanner:
         function may be called from a background thread.
         """
         self.hidden = False
-        GLib.idle_add(self.restore)
+        self.restore()
 
     def restore(self, *_):
         """Restore Minimized Window"""

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -67,6 +67,9 @@ def configure():
     conf = configparser.ConfigParser()
     conf.read(CONF_FILE)
     if conf.has_section("global"):
+        unrecognized = [ key for key, _ in conf.items("global") if key not in defaults.keys() ]
+        if len(unrecognized) > 0:
+            print("The following options in the {} were unrecognized:\n{}".format(CONF_FILE, unrecognized))
         for key, val in conf.items("global"):
             if re.match(r"^[0-9]+$", val):
                 defaults[key] = conf.getint("global", key)

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -339,17 +339,18 @@ class DisplayBanner:
                     self.y = screen.split('x')[1].split('+')[0]
 
                 except IndexError:
-                    self.screen = os.popen(  # nosec
-                        r"/usr/bin/xrandr | grep '^\*0' | awk '{ print $2$3$4 }'").readlines()[0]
-                    self.x = self.screen.split('x')[0]
-                    self.y = self.screen.split('x')[1].split('+')[0]
+                    try:
+                        self.screen = os.popen(  # nosec
+                            r"/usr/bin/xrandr | grep '^\*0' | awk '{ print $2$3$4 }'").readlines()[0]
+                        self.x = self.screen.split('x')[0]
+                        self.y = self.screen.split('x')[1].split('+')[0]
 
-                else:
-                    # Fail back to GTK method
-                    self.display = Gdk.Display.get_default()
-                    self.screen = self.display.get_default_screen()
-                    self.x = self.screen.get_width()
-                    self.y = self.screen.get_height()
+                    except:
+                        # Fail back to GTK method
+                        self.display = Gdk.Display.get_default()
+                        self.screen = self.display.get_default_screen()
+                        self.x = self.screen.get_width()
+                        self.y = self.screen.get_height()
         else:
             # Resoultion Set Staticly
             self.x = options.hres

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -72,7 +72,7 @@ def configure():
         ]
         if len(unrecognized) > 0:
             print(
-                "The following options in the {CONF_FILE} were unrecognized:\n{unrecognized}"
+                f"The following options in the {CONF_FILE} were unrecognized:\n{unrecognized}"
             )
         for key, val in conf.items("global"):
             if re.match(r"^[0-9]+$", val):

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -327,6 +327,9 @@ class DisplayBanner:
         num_monitors = self.display.get_n_monitors()
 
         if options.hres == 0 or options.vres == 0:
+            if options.hres != 0 or options.vres != 0:
+                print("hres or vres specified, but not both, ignoring...")
+
             # Try Xrandr to determine primary monitor resolution
             try:
                 screen = os.popen(  # nosec

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -326,7 +326,7 @@ class DisplayBanner:
 
         # Newer versions of pygtk have this method
         try:
-            self.monitor.connet("monitors-changed", self.resize)
+            self.monitor.connect("monitors-changed", self.resize)
         except AttributeError:
             pass
 

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -66,9 +66,14 @@ def configure():
     conf = configparser.ConfigParser()
     conf.read(CONF_FILE)
     if conf.has_section("global"):
-        unrecognized = [ key for key, _ in conf.items("global") if key not in defaults.keys() ]
+        known_keys = defaults.keys()
+        unrecognized = [
+            key for key, _ in conf.items("global") if key not in known_keys
+        ]
         if len(unrecognized) > 0:
-            print("The following options in the {} were unrecognized:\n{}".format(CONF_FILE, unrecognized))
+            print(
+                "The following options in the {CONF_FILE} were unrecognized:\n{unrecognized}"
+            )
         for key, val in conf.items("global"):
             if re.match(r"^[0-9]+$", val):
                 defaults[key] = conf.getint("global", key)
@@ -301,7 +306,7 @@ class ClassificationBanner:
 
         return True
 
-    def keypress(self, widget=None, event=None):
+    def keypress(self, _widget=None, event=None):
         """Press ESC to hide window for 15 seconds"""
         if event.keyval == 65307:
             if not Gtk.events_pending() and not self.hidden:
@@ -311,6 +316,7 @@ class ClassificationBanner:
                 GLib.timeout_add(15000, self._restore)
 
         return True
+
 
 class DisplayBanner:
     """Display Classification Banner Message"""
@@ -362,7 +368,7 @@ class DisplayBanner:
                         self.x = self.screen.split('x')[0]
                         self.y = self.screen.split('x')[1].split('+')[0]
 
-                    except:
+                    except IndexError:
                         # Fail back to GTK method
                         self.display = Gdk.Display.get_default()
                         self.screen = self.display.get_default_screen()

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -267,7 +267,7 @@ class ClassificationBanner:
         self.apply_css(self.window, provider)
 
         try:
-            self.window.set_opacit(opacity)
+            self.window.set_opacity(opacity)
         except AttributeError:  # nosec
             pass
 

--- a/classification_banner/banner.py
+++ b/classification_banner/banner.py
@@ -5,8 +5,6 @@
 import sys
 import os
 import argparse
-import time
-import threading
 import re
 import configparser
 from socket import gethostname
@@ -281,11 +279,12 @@ class ClassificationBanner:
         """
         Restore an intentionally hidden banner.
 
-        UI functions called here are wrapped in `GLib.idle_add` because this
-        function may be called from a background thread.
+        This method returns False intentionally to destroy the timeout it is
+        called by.
         """
         self.hidden = False
         self.restore()
+        return False
 
     def restore(self, *_):
         """Restore Minimized Window"""
@@ -309,7 +308,7 @@ class ClassificationBanner:
                 self.hidden = True
                 self.window.iconify()
                 self.window.hide()
-                threading.Timer(15, self._restore).start()
+                GLib.timeout_add(15000, self._restore)
 
         return True
 


### PR DESCRIPTION
Main goal was to fix the hiding functionality. Other things bothered me along the way.

Changes boil down to:
* `/etc/classification-banner/banner.conf` file is no longer required. Previously, the script would error out in a manner not immediately apparent that it was not finding a configuration file (or was given an improper configuration file).
* Fixed fallback to GTK for screen size detection. `xrandr` is still attempted to be called three times if it's not present or fails for any reason though.
* Added some warnring prints for improper config/arguments.
* Fixed ESC to hide functionality
* Fixed opacity setting

Tested on Fedora 38.

Closes #12 
Closes #14 
Closes #16 